### PR TITLE
Ignore unavailable

### DIFF
--- a/conf/inky_config.yaml
+++ b/conf/inky_config.yaml
@@ -1,0 +1,88 @@
+
+resources_path: "resources"
+font: "MesloLGS NF Regular.ttf"
+
+
+homemonitor:
+  refresh_period: 600
+  fields_configuration: 
+    weather:
+      influxdb_connector: homemonitor
+      measurement: openweather_current_weather
+      fields:
+        temperature: temp
+        humidity: humidity
+        wind_speed: wind_speed
+        weather_description: weather_description
+    salon:
+      influxdb_connector: homemonitor
+      measurement: bme688
+      fields: 
+        temperature: temperature
+        humidity: humidity
+    cuisine:
+      influxdb_connector: pi
+      measurement: bme280
+      fields:
+        temperature: temperature
+        humidity: humidity
+    elec:
+      influxdb_connector: pi
+      measurement: teleinfo
+      fields:
+        app_power: PAPP
+
+dayweather:
+  refresh_period: 600
+  gps_coordinates: [48.85, 2.35]
+
+citiesweather:
+  refresh_period: 1800
+  cities:
+    - "Carnac, FR"
+    - "Peisey-Nancroix, FR"
+    - "Avignon"
+    - "New York, US"
+
+elecconsumption:
+  refresh_period: 300
+  fields_configuration:
+    influxdb_connector: pi
+    measurement: teleinfo
+    fields:
+      app_power: PAPP
+      total_power: BASE 
+
+sysmonitor:
+  refresh_period: 600
+  fields_configuration:
+    pi:
+      cpu_usage:
+        measurement: system_2
+        field: cpu_usage
+      ram_usage:
+        measurement: system_2
+        field: ram_usage
+      mem_usage: 
+        measurement: system_1
+        field: memory_usage
+        max_value: 29
+      cpu_temp: 
+        measurement: system_1
+        field: cpu_temperature
+        max_value: 85
+    homemonitor:
+      cpu_usage:
+        measurement: system_hm_2
+        field: cpu_usage
+      ram_usage:
+        measurement: system_hm_2
+        field: ram_usage
+      mem_usage: 
+        measurement: system_hm_1
+        field: memory_usage
+        max_value: 30
+      cpu_temp: 
+        measurement: system_hm_1
+        field: cpu_temperature
+        max_value: 85

--- a/conf/streaming_config.yaml
+++ b/conf/streaming_config.yaml
@@ -1,4 +1,4 @@
-title: "Maison Avignon"
+title: "Maison Carnac"
 
 temperature_thresholds: &temperature_thresholds
   18: blue
@@ -44,7 +44,7 @@ indicators_parameters:
   window_size: 10m
 
 layouts:
-  - title: "Capteurs entree"
+  - title: "Capteurs salon"
     influxdb_connector: homemonitor
     indicators:
       - type: number
@@ -124,7 +124,7 @@ layouts:
         field: weather_description
         refresh_rate: 10m
 
-  - title: "Pi entree"
+  - title: "Pi salon"
     influxdb_connector: homemonitor
     indicators:
       - type: gauge


### PR DESCRIPTION
- Influxdb queries now return None if the value is missing. Avoid errors on database querying
- If a measure is missing, the dashboard now display a message instead